### PR TITLE
Fix the dmenu launcher

### DIFF
--- a/yt
+++ b/yt
@@ -8,7 +8,8 @@
 
 defcmd="fzf"
 guicmd="rofi -dmenu -i" #uncomment next line for dmenu
-#guicmd="dmenu -i -l 15"
+#guicmd="dmenu -l 15"
+#demnu -i is not a valid switch in dmenu-5.0
 promptcmd="$defcmd"
 if [ -z "$*" ]; then 
 	echo -n "Search: "


### PR DESCRIPTION
-i is not a valid switch in 5.0 
when I uncommented the line it did not spawn the dmenu window due to this.