### PR TITLE
Store history and be able to add playlists

### DIFF
--- a/yt
+++ b/yt
@@ -45,6 +45,7 @@ function usage() {
   echo "    -H        view watch history"
   echo "    -p        view saved playlists"
   echo "    -P url    add playlist to saved playlists"
+  echo "    -x url    play a youtube mix (remember to quote the url)"
   echo "  nothing     use defaults (search from prompt)"
   echo
   echo "add channel names to the file $sublistpath to show them"
@@ -70,7 +71,7 @@ if [[ ${#} -eq 0 ]]; then
 fi
 
 # available flags
-optstring=":s:c:P:grhHpm"
+optstring=":s:c:P:x:grhHpm"
 
 defcmd="fzf"
 defaction="s"
@@ -110,56 +111,62 @@ sublist=""
 
 # if not using defaults search for flags
 if [[ $useDefaults = "f" ]]; then
-  while getopts ${optstring} arg; do
+  while getopts ${optstring} arg;
+  do
     case "${arg}" in
     s)
       # search in youtube for a query
       action="s"
       query="${OPTARG}"
-      ;;
+      ;; 
     c)
       # search in subscriptions for specific channel
       action="c"
       query="${OPTARG}"
-      ;;
+      ;; 
     g | r)
       # set gui mode to true and change the prompt to gui prompt
       isGui="t"
       promptcmd="$guicmd"
-      ;;
+      ;; 
     m)
       # make the mpv headless
       mpv_options+="--no-video"
-      ;;
+      ;; 
     H)
       # view watch history
       action="H"
-      ;;
+      ;; 
     p)
       # view saved playlists
       action="p"
-      ;;
+      ;; 
     P)
       # add playlist to saved playlists
       action="P"
       query="${OPTARG}"
-      ;;
+      ;; 
+    x)
+      # play a youtube mix
+      action="x"
+      query="${OPTARG}"
+      ;; 
     h)
       # display help / usage
       usage
-      ;;
+      ;; 
     \?)
       # wrong args -> exit with explanation of usage
       echo "invalid option: -${OPTARG}"
       echo
       usage
-      ;;
+      ;; 
     :)
       # missing args -> exit with explanation of usage
       echo "Option -${OPTARG} needs an argument"
       echo
       usage
-      ;;
+      ;; 
     esac
   done
 fi
@@ -195,7 +202,7 @@ if [ -z "$query" ]; then
     if [ -n "$query" ]; then
       echo "Playing from history: $query"
       # Extract title from history entry for re-saving
-      title=$(extract_field "$query" $'\t' 2)
+      title=$(extract_field "$query" $'	' 2)
       play "$query" "$title"
       exit 0
     fi
@@ -218,7 +225,7 @@ if [ -z "$query" ]; then
     if [ -n "$query" ]; then
       echo "Playing playlist: $query"
       # Extract title from playlist entry for saving to history
-      title=$(extract_field "$query" $'\t' 2)
+      title=$(extract_field "$query" $'	' 2)
       play "$query" "$title"
       exit 0
     fi
@@ -261,6 +268,23 @@ if [[ $action = "P" ]]; then
   fi
 fi
 
+# handle playing a mix
+if [[ $action = "x" ]]; then
+  if [ -n "$query" ]; then
+    echo "Playing mix: $query"
+    # Add playlist options for mix playback
+    mix_options="$mpv_options --playlist-start=0 --ytdl-raw-options=yes-playlist="
+    save_to_history "$query" "YouTube Mix"
+    mpv "$query" $mix_options --ytdl-format="$ytdlformats"
+    exit 0
+  else
+    echo "Please provide a mix URL"
+    echo "Usage: yt -x 'URL'"
+    echo "Note: Remember to quote the URL if it contains special characters like '&'."
+    exit 1
+  fi
+fi
+
 # program cancelled -> exit
 if [ -z "$query" ]; then exit; fi
 
@@ -293,29 +317,30 @@ if [[ $action = "c" ]]; then
 
   # prompt the results to user infinitely until they exit (escape)
   while true; do
-    choice=$(echo -e "$ids" | cut -d$'\t' -f2 | $promptcmd)       # dont show id
+    choice=$(echo -e "$ids" | cut -d$'	' -f2 | $promptcmd)       # dont show id
     if [ -z "$choice" ]; then exit; fi                          # if esc-ed then exit
-    id=$(echo -e "$ids" | grep -Fwm1 "$choice" | cut -d$'\t' -f1) # get id of choice
+    id=$(echo -e "$ids" | grep -Fwm1 "$choice" | cut -d$'	' -f1) # get id of choice
     echo -e "$choice\t($id)"
     case $id in
-    ???????????) 
+    ???????????)
       url="$videolink$id"
-      play "$url" "$choice" ;;
-    *) exit ;;
+      play "$url" "$choice" ;; 
+    *)
+      exit ;; 
     esac
   done
 else
   # if in search show query result vids
   response="$(curl -s "https://www.youtube.com/results?search_query=$query" |
-    sed 's|\\.||g')"
+    sed 's|\.||g')"
   # if unable to fetch the youtube results page, inform and exit
   if ! grep -q "script" <<<"$response"; then
     echo "unable to fetch yt"
     exit 1
   fi
   # regex expression to match video and playlist entries from yt result page
-  vgrep='"videoRenderer":{"videoId":"\K.{11}".+?"text":".+?[^\\](?=")'
-  pgrep='"playlistRenderer":{"playlistId":"\K.{34}?","title":{"simpleText":".+?[^\"](?=")'
+  vgrep='"videoRenderer":{"videoId":"\K.{11}".+?"text":".+?[^\\](?="'
+  pgrep='"playlistRenderer":{"playlistId":"\K.{34}?","title":{"simpleText":".+?[^\"](?="'
   # grep the id and title
   # return them in format id (type) title
   getresults() {
@@ -333,20 +358,21 @@ else
   playlink="https://youtube.com/playlist?list="
   # prompt the results to user infinitely until they exit (escape)
   while true; do
-    choice=$(echo -e "$ids" | cut -d$'\t' -f2 | $promptcmd)       # dont show id
+    choice=$(echo -e "$ids" | cut -d$'	' -f2 | $promptcmd)       # dont show id
     if [ -z "$choice" ]; then exit; fi                          # if esc-ed then exit
-    id=$(echo -e "$ids" | grep -Fwm1 "$choice" | cut -d$'\t' -f1) # get id of choice
+    id=$(echo -e "$ids" | grep -Fwm1 "$choice" | cut -d$'	' -f1) # get id of choice
     echo -e "$choice\t($id)"
     case $id in
     # 11 digit id = video
-    ???????????) 
+    ???????????)
       url="$videolink$id"
-      play "$url" "$choice" ;;
+      play "$url" "$choice" ;; 
     # 34 digit id = playlist
-    ??????????????????????????????????) 
+    ??????????????????????????????????)
       url="$playlink$id"
-      play "$url" "$choice" ;;
-    *) exit ;;
+      play "$url" "$choice" ;; 
+    *)
+      exit ;; 
     esac
   done
 fi

--- a/yt
+++ b/yt
@@ -26,6 +26,14 @@ save_to_history() {
   echo -e "$url\t$title\t$timestamp" >> "$historypath"
 }
 
+# function to save to history and play via mpv
+play() {
+  local url="$1"
+  local choice="$2"
+  save_to_history "$url" "$choice"
+  mpv "$url" $mpv_options --ytdl-format="$ytdlformats"
+}
+
 # explain usage
 function usage() {
   echo "usage: yt"
@@ -188,8 +196,7 @@ if [ -z "$query" ]; then
       echo "Playing from history: $query"
       # Extract title from history entry for re-saving
       title=$(extract_field "$query" $'\t' 2)
-      save_to_history "$query" "$title"
-      mpv "$query" $mpv_options --ytdl-format="$ytdlformats"
+      play "$query" "$title"
       exit 0
     fi
   # view saved playlists
@@ -212,8 +219,7 @@ if [ -z "$query" ]; then
       echo "Playing playlist: $query"
       # Extract title from playlist entry for saving to history
       title=$(extract_field "$query" $'\t' 2)
-      save_to_history "$query" "$title"
-      mpv "$query" $mpv_options --ytdl-format="$ytdlformats"
+      play "$query" "$title"
       exit 0
     fi
   else
@@ -294,8 +300,7 @@ if [[ $action = "c" ]]; then
     case $id in
     ???????????) 
       url="$videolink$id"
-      save_to_history "$url" "$choice"
-      mpv "$url" "$mpv_options" --ytdl-format="$ytdlformats" ;;
+      play "$url" "$choice" ;;
     *) exit ;;
     esac
   done
@@ -336,13 +341,11 @@ else
     # 11 digit id = video
     ???????????) 
       url="$videolink$id"
-      save_to_history "$url" "$choice"
-      mpv "$url" $mpv_options --ytdl-format="$ytdlformats" ;;
+      play "$url" "$choice" ;;
     # 34 digit id = playlist
     ??????????????????????????????????) 
       url="$playlink$id"
-      save_to_history "$url" "$choice"
-      mpv "$url" $mpv_options --ytdl-format="$ytdlformats" ;;
+      play "$url" "$choice" ;;
     *) exit ;;
     esac
   done

--- a/yt
+++ b/yt
@@ -10,27 +10,38 @@
 
 # NOTE:  if you dont have GNU grep you can replace grep with rg
 
+# function to save video/playlist to history
+save_to_history() {
+  local url="$1"
+  local title="$2"
+  local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+  echo "$url	$title	$timestamp" >> "$historypath"
+}
+
 # explain usage
-function usage () {
+function usage() {
   echo "usage: yt"
   echo "    -h        help"
   echo "    -c        channels/subscriptions"
   echo "    -s query  search"
   echo "    -g / -r   gui mode (rofi/dmenu)"
   echo "    -m        music mode (audio only) [dont use with -r]"
+  echo "    -H        view watch history"
+  echo "    -p        view saved playlists"
+  echo "    -P url    add playlist to saved playlists"
   echo "  nothing     use defaults (search from prompt)"
-	echo
-	echo "add channel names to the file $sublistpath to show them"
-	echo "in yt -c option. First word should be channel url, optionally"
-	echo "followed by tab and then anything else (channel name/description)"
-	echo "channels not in sublist can be viewed by typing their url in the prompt"
-	echo
-	echo "example file format:"
-	echo "markrober       Mark Rober"
-	echo "vsauce1         VSauce          Michael Steven's Channel"
-	echo "BlackGryph0n    Black Gryph0n   Gabriel Brown signs stuff"
-	echo "TomScottGo      Tom Scott"
-	echo "danielthrasher  Daniel Thrasher"
+  echo
+  echo "add channel names to the file $sublistpath to show them"
+  echo "in yt -c option. First word should be channel url, optionally"
+  echo "followed by tab and then anything else (channel name/description)"
+  echo "channels not in sublist can be viewed by typing their url in the prompt"
+  echo
+  echo "example file format:"
+  echo "markrober       Mark Rober"
+  echo "vsauce1         VSauce          Michael Steven's Channel"
+  echo "BlackGryph0n    Black Gryph0n   Gabriel Brown signs stuff"
+  echo "TomScottGo      Tom Scott"
+  echo "danielthrasher  Daniel Thrasher"
   exit 0
 }
 
@@ -39,11 +50,11 @@ useDefaults="f"
 
 # no args -> use defaults
 if [[ ${#} -eq 0 ]]; then
-    useDefaults="t"
+  useDefaults="t"
 fi
 
 # available flags
-optstring=":s:cgrhm"
+optstring=":s:c:P:grhHpm"
 
 defcmd="fzf"
 defaction="s"
@@ -62,13 +73,13 @@ max_fps="30"
 ignore_codec=""
 ytdlformats="bestvideo"
 
-if [ -n "$max_resolution" ] ; then
+if [ -n "$max_resolution" ]; then
   ytdlformats+="[height<=?$max_resolution]"
 fi
-if [ -n "$max_fps" ] ; then
+if [ -n "$max_fps" ]; then
   ytdlformats+="[fps<=?$max_fps]"
 fi
-if [ -n "$ignore_codec" ] ; then
+if [ -n "$ignore_codec" ]; then
   ytdlformats+="[vcodec!=$ignore_codec]"
 fi
 ytdlformats+="+bestaudio/best"
@@ -76,68 +87,164 @@ ytdlformats+="+bestaudio/best"
 # subscription list
 mkdir -p "${HOME:-}/.config/yt"
 sublistpath="${HOME:-}/.config/yt/sublist"
+historypath="${HOME:-}/.config/yt/history"
+playlistspath="${HOME:-}/.config/yt/playlists"
 sublist=""
 [ -f "$sublistpath" ] && sublist=$(cat "$sublistpath")
 
 # if not using defaults search for flags
 if [[ $useDefaults = "f" ]]; then
-    while getopts ${optstring} arg; do
-        case "${arg}" in
-            s)
-                # search in youtube for a query
-                action="s"
-                query="${OPTARG}" ;;
-            c)
-                # search in subscriptions for specific channel
-                action="c"
-                query="${OPTARG}" ;;
-            g|r)
-                # set gui mode to true and change the prompt to gui prompt
-                isGui="t"
-                promptcmd="$guicmd" ;;
-            m)
-               # make the mpv headless
-                mpv_options+="--no-video" ;;
-            h)
-                # display help / usage
-                usage ;;
-            \?)
-                # wrong args -> exit with explanation of usage
-                echo "invalid option: -${OPTARG}"
-                echo
-                usage ;;
-            :)
-                # missing args -> exit with explanation of usage
-                echo "Option -${OPTARG} needs an argument"
-                echo
-                usage ;;
-        esac
-    done
+  while getopts ${optstring} arg; do
+    case "${arg}" in
+    s)
+      # search in youtube for a query
+      action="s"
+      query="${OPTARG}"
+      ;;
+    c)
+      # search in subscriptions for specific channel
+      action="c"
+      query="${OPTARG}"
+      ;;
+    g | r)
+      # set gui mode to true and change the prompt to gui prompt
+      isGui="t"
+      promptcmd="$guicmd"
+      ;;
+    m)
+      # make the mpv headless
+      mpv_options+="--no-video"
+      ;;
+    H)
+      # view watch history
+      action="H"
+      ;;
+    p)
+      # view saved playlists
+      action="p"
+      ;;
+    P)
+      # add playlist to saved playlists
+      action="P"
+      query="${OPTARG}"
+      ;;
+    h)
+      # display help / usage
+      usage
+      ;;
+    \?)
+      # wrong args -> exit with explanation of usage
+      echo "invalid option: -${OPTARG}"
+      echo
+      usage
+      ;;
+    :)
+      # missing args -> exit with explanation of usage
+      echo "Option -${OPTARG} needs an argument"
+      echo
+      usage
+      ;;
+    esac
+  done
 fi
 
 # if no query is set with flags then ask for one
 if [ -z "$query" ]; then
-    # ask for a channel
-    if [[ $action = "c" ]]; then
-        # if in gui mode use gui prompt
-        if [[ $isGui = "t" ]]; then
-			query=$($promptcmd -p "Channel: " <<< "$sublist")
-            promptcmd="$promptcmd -p Video:"
-        else
-            query=$($promptcmd --print-query <<< "$sublist" | tail -n1)
-        fi
-		query=$(echo "$query" | awk '{print $1}')
+  # ask for a channel
+  if [[ $action = "c" ]]; then
+    # if in gui mode use gui prompt
+    if [[ $isGui = "t" ]]; then
+      query=$($promptcmd -p "Channel: " <<<"$sublist")
+      promptcmd="$promptcmd -p Video:"
     else
-        # ask for a query
-        # if in gui mode use gui prompt
-        if [[ $isGui = "t" ]]; then
-            query=$(echo | $promptcmd -p "Search: ")
-            promptcmd="$promptcmd -p Video:"
-        else
-            echo -n "Search: "
-            read -r query
-        fi
+      query=$($promptcmd --print-query <<<"$sublist" | tail -n1)
     fi
+    query=$(echo "$query" | awk '{print $1}')
+  # view watch history
+  elif [[ $action = "H" ]]; then
+    if [ ! -f "$historypath" ]; then
+      echo "No watch history found"
+      exit 0
+    fi
+    # if in gui mode use gui prompt
+    if [[ $isGui = "t" ]]; then
+      query=$($promptcmd -p "History: " <"$historypath")
+      promptcmd="$promptcmd -p Video:"
+    else
+      query=$($promptcmd --print-query <"$historypath" | tail -n1)
+    fi
+    # extract URL from history entry
+    query=$(echo "$query" | awk '{print $1}')
+    # play directly from history
+    if [ -n "$query" ]; then
+      echo "Playing from history: $query"
+      # Extract title from history entry for re-saving
+      title=$(echo "$query" | cut -d'	' -f2)
+      save_to_history "$query" "$title"
+      mpv "$query" $mpv_options --ytdl-format="$ytdlformats"
+      exit 0
+    fi
+  # view saved playlists
+  elif [[ $action = "p" ]]; then
+    if [ ! -f "$playlistspath" ]; then
+      echo "No saved playlists found"
+      exit 0
+    fi
+    # if in gui mode use gui prompt
+    if [[ $isGui = "t" ]]; then
+      query=$($promptcmd -p "Playlist: " <"$playlistspath")
+      promptcmd="$promptcmd -p Video:"
+    else
+      query=$($promptcmd --print-query <"$playlistspath" | tail -n1)
+    fi
+    # extract URL from playlist entry
+    query=$(echo "$query" | awk '{print $1}')
+    # play playlist directly
+    if [ -n "$query" ]; then
+      echo "Playing playlist: $query"
+      # Extract title from playlist entry for saving to history
+      title=$(echo "$query" | cut -d'	' -f2)
+      save_to_history "$query" "$title"
+      mpv "$query" $mpv_options --ytdl-format="$ytdlformats"
+      exit 0
+    fi
+  else
+    # ask for a query
+    # if in gui mode use gui prompt
+    if [[ $isGui = "t" ]]; then
+      query=$(echo | $promptcmd -p "Search: ")
+      promptcmd="$promptcmd -p Video:"
+    else
+      echo -n "Search: "
+      read -r query
+    fi
+  fi
+fi
+
+# handle adding playlist to saved playlists
+if [[ $action = "P" ]]; then
+  if [ -n "$query" ]; then
+    # validate if it's a valid YouTube playlist URL
+    if [[ $query =~ ^https?://(www\.)?youtube\.com/playlist\?list= ]] || [[ $query =~ ^https?://youtu\.be/.*\&list= ]]; then
+      # Try to get playlist title (basic extraction)
+      echo -n "Enter playlist name (or press Enter to use URL): "
+      read -r playlist_name
+      if [ -z "$playlist_name" ]; then
+        playlist_name="Playlist"
+      fi
+      echo "$query	$playlist_name	$(date '+%Y-%m-%d %H:%M:%S')" >> "$playlistspath"
+      echo "Playlist '$playlist_name' added to saved playlists"
+      exit 0
+    else
+      echo "Invalid playlist URL. Please provide a valid YouTube playlist URL"
+      echo "Example: https://www.youtube.com/playlist?list=PLxxxxxxxxxxxxxxx"
+      exit 1
+    fi
+  else
+    echo "Please provide a playlist URL"
+    echo "Usage: yt -P 'https://www.youtube.com/playlist?list=PLxxxxxxxxxxxxxxx'"
+    exit 1
+  fi
 fi
 
 # program cancelled -> exit
@@ -145,76 +252,90 @@ if [ -z "$query" ]; then exit; fi
 
 # clean query / channel
 query=$(sed \
-  -e 's|+|%2B|g'\
-  -e 's|#|%23|g'\
-  -e 's|&|%26|g'\
-  -e 's| |+|g' <<< "$query")
-
+  -e 's|+|%2B|g' \
+  -e 's|#|%23|g' \
+  -e 's|&|%26|g' \
+  -e 's| |+|g' <<<"$query")
 
 # if channel look for channel vids
 if [[ $action = "c" ]]; then
-    response=$(curl -s "https://www.youtube.com/c/$query/videos" |\
-      sed "s/{\"videoRenderer/\n\n&/g" |\
-      sed "s/}]}}}]}}/&\n\n/g" |\
-      awk -v ORS="\n\n" '/videoRenderer/')
+  response=$(curl -s "https://www.youtube.com/c/$query/videos" |
+    sed "s/{\"videoRenderer/\n\n&/g" |
+    sed "s/}]}}}]}}/&\n\n/g" |
+    awk -v ORS="\n\n" '/videoRenderer/')
 
-    # if unable to fetch the youtube results page, inform and exit
-    if ! grep -q "videoRenderer" <<< "$response"; then echo "unable to fetch yt"; exit 1; fi
+  # if unable to fetch the youtube results page, inform and exit
+  if ! grep -q "videoRenderer" <<<"$response"; then
+    echo "unable to fetch yt"
+    exit 1
+  fi
 
-    # regex expression to match video entries from yt channel page
-    # get the list of videos and their ids to ids
-    ids=$(awk -F '[""]' '{print $6 "\t" $50;}' <<< "$response" | grep "^\S")
+  # regex expression to match video entries from yt channel page
+  # get the list of videos and their ids to ids
+  ids=$(awk -F '[""]' '{print $6 "\t" $50;}' <<<"$response" | grep "^\S")
 
-    # url prefix for videos
-    videolink="https://youtu.be/"
+  # url prefix for videos
+  videolink="https://youtu.be/"
 
-    # prompt the results to user infinitely until they exit (escape)
-    while true; do
-      choice=$(echo -e "$ids" | cut -d'	' -f2 | $promptcmd) # dont show id
-      if [ -z "$choice" ]; then exit; fi	# if esc-ed then exit
-      id=$(echo -e "$ids" | grep -Fwm1 "$choice" | cut -d'	' -f1) # get id of choice
-      echo -e "$choice\t($id)"
-      case $id in
-          ???????????) mpv "$videolink$id" "$mpv_options" --ytdl-format="$ytdlformats";;
-          *) exit ;;
-      esac
-    done
+  # prompt the results to user infinitely until they exit (escape)
+  while true; do
+    choice=$(echo -e "$ids" | cut -d'	' -f2 | $promptcmd)       # dont show id
+    if [ -z "$choice" ]; then exit; fi                          # if esc-ed then exit
+    id=$(echo -e "$ids" | grep -Fwm1 "$choice" | cut -d'	' -f1) # get id of choice
+    echo -e "$choice\t($id)"
+    case $id in
+    ???????????) 
+      url="$videolink$id"
+      save_to_history "$url" "$choice"
+      mpv "$url" "$mpv_options" --ytdl-format="$ytdlformats" ;;
+    *) exit ;;
+    esac
+  done
 else
-    # if in search show query result vids
-    response="$(curl -s "https://www.youtube.com/results?search_query=$query" |\
-      sed 's|\\.||g')"
-    # if unable to fetch the youtube results page, inform and exit
-    if ! grep -q "script" <<< "$response"; then echo "unable to fetch yt"; exit 1; fi
-    # regex expression to match video and playlist entries from yt result page
-    vgrep='"videoRenderer":{"videoId":"\K.{11}".+?"text":".+?[^\\](?=")'
-    pgrep='"playlistRenderer":{"playlistId":"\K.{34}?","title":{"simpleText":".+?[^\"](?=")'
-    # grep the id and title
-    # return them in format id (type) title
-    getresults() {
-        grep -oP "$1" <<< "$response" |\
-          awk -F\" -v p="$2" '{ print $1 "\t" p " " $NF}'
-    }
-    # get the list of videos/playlists and their ids in videoids and playlistids
-    videoids=$(getresults "$vgrep")
-    playlistids=$(getresults "$pgrep" "(playlist)")
-    # if there are playlists or videos, append them to list
-    [ -n "$playlistids" ] && ids="$playlistids\n"
-    [ -n "$videoids" ] && ids="$ids$videoids"
-    # url prefix for videos and playlists
-    videolink="https://youtu.be/"
-    playlink="https://youtube.com/playlist?list="
-    # prompt the results to user infinitely until they exit (escape)
-    while true; do
-        choice=$(echo -e "$ids" | cut -d'	' -f2 | $promptcmd) # dont show id
-        if [ -z "$choice" ]; then exit; fi	# if esc-ed then exit
-        id=$(echo -e "$ids" | grep -Fwm1 "$choice" | cut -d'	' -f1) # get id of choice
-        echo -e "$choice\t($id)"
-        case $id in
-            # 11 digit id = video
-            ???????????) mpv "$videolink$id" $mpv_options --ytdl-format="$ytdlformats";;
-            # 34 digit id = playlist
-            ??????????????????????????????????) mpv "$playlink$id" $mpv_options --ytdl-format="$ytdlformats";;
-            *) exit ;;
-        esac
-    done
+  # if in search show query result vids
+  response="$(curl -s "https://www.youtube.com/results?search_query=$query" |
+    sed 's|\\.||g')"
+  # if unable to fetch the youtube results page, inform and exit
+  if ! grep -q "script" <<<"$response"; then
+    echo "unable to fetch yt"
+    exit 1
+  fi
+  # regex expression to match video and playlist entries from yt result page
+  vgrep='"videoRenderer":{"videoId":"\K.{11}".+?"text":".+?[^\\](?=")'
+  pgrep='"playlistRenderer":{"playlistId":"\K.{34}?","title":{"simpleText":".+?[^\"](?=")'
+  # grep the id and title
+  # return them in format id (type) title
+  getresults() {
+    grep -oP "$1" <<<"$response" |
+      awk -F\" -v p="$2" '{ print $1 "\t" p " " $NF}'
+  }
+  # get the list of videos/playlists and their ids in videoids and playlistids
+  videoids=$(getresults "$vgrep")
+  playlistids=$(getresults "$pgrep" "(playlist)")
+  # if there are playlists or videos, append them to list
+  [ -n "$playlistids" ] && ids="$playlistids\n"
+  [ -n "$videoids" ] && ids="$ids$videoids"
+  # url prefix for videos and playlists
+  videolink="https://youtu.be/"
+  playlink="https://youtube.com/playlist?list="
+  # prompt the results to user infinitely until they exit (escape)
+  while true; do
+    choice=$(echo -e "$ids" | cut -d'	' -f2 | $promptcmd)       # dont show id
+    if [ -z "$choice" ]; then exit; fi                          # if esc-ed then exit
+    id=$(echo -e "$ids" | grep -Fwm1 "$choice" | cut -d'	' -f1) # get id of choice
+    echo -e "$choice\t($id)"
+    case $id in
+    # 11 digit id = video
+    ???????????) 
+      url="$videolink$id"
+      save_to_history "$url" "$choice"
+      mpv "$url" $mpv_options --ytdl-format="$ytdlformats" ;;
+    # 34 digit id = playlist
+    ??????????????????????????????????) 
+      url="$playlink$id"
+      save_to_history "$url" "$choice"
+      mpv "$url" $mpv_options --ytdl-format="$ytdlformats" ;;
+    *) exit ;;
+    esac
+  done
 fi

--- a/yt
+++ b/yt
@@ -10,12 +10,20 @@
 
 # NOTE:  if you dont have GNU grep you can replace grep with rg
 
+# utility function to extract field from delimited string
+extract_field() {
+  local input="$1"
+  local delimiter="$2"
+  local field="$3"
+  echo "$input" | cut -d"$delimiter" -f"$field"
+}
+
 # function to save video/playlist to history
 save_to_history() {
   local url="$1"
   local title="$2"
   local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
-  echo "$url	$title	$timestamp" >> "$historypath"
+  echo -e "$url\t$title\t$timestamp" >> "$historypath"
 }
 
 # explain usage
@@ -159,7 +167,7 @@ if [ -z "$query" ]; then
     else
       query=$($promptcmd --print-query <<<"$sublist" | tail -n1)
     fi
-    query=$(echo "$query" | awk '{print $1}')
+    query=$(extract_field "$query" ' ' 1)
   # view watch history
   elif [[ $action = "H" ]]; then
     if [ ! -f "$historypath" ]; then
@@ -174,12 +182,12 @@ if [ -z "$query" ]; then
       query=$($promptcmd --print-query <"$historypath" | tail -n1)
     fi
     # extract URL from history entry
-    query=$(echo "$query" | awk '{print $1}')
+    query=$(extract_field "$query" ' ' 1)
     # play directly from history
     if [ -n "$query" ]; then
       echo "Playing from history: $query"
       # Extract title from history entry for re-saving
-      title=$(echo "$query" | cut -d'	' -f2)
+      title=$(extract_field "$query" $'\t' 2)
       save_to_history "$query" "$title"
       mpv "$query" $mpv_options --ytdl-format="$ytdlformats"
       exit 0
@@ -198,12 +206,12 @@ if [ -z "$query" ]; then
       query=$($promptcmd --print-query <"$playlistspath" | tail -n1)
     fi
     # extract URL from playlist entry
-    query=$(echo "$query" | awk '{print $1}')
+    query=$(extract_field "$query" ' ' 1)
     # play playlist directly
     if [ -n "$query" ]; then
       echo "Playing playlist: $query"
       # Extract title from playlist entry for saving to history
-      title=$(echo "$query" | cut -d'	' -f2)
+      title=$(extract_field "$query" $'\t' 2)
       save_to_history "$query" "$title"
       mpv "$query" $mpv_options --ytdl-format="$ytdlformats"
       exit 0
@@ -232,7 +240,7 @@ if [[ $action = "P" ]]; then
       if [ -z "$playlist_name" ]; then
         playlist_name="Playlist"
       fi
-      echo "$query	$playlist_name	$(date '+%Y-%m-%d %H:%M:%S')" >> "$playlistspath"
+      echo -e "$query\t$playlist_name\t$(date '+%Y-%m-%d %H:%M:%S')" >> "$playlistspath"
       echo "Playlist '$playlist_name' added to saved playlists"
       exit 0
     else
@@ -279,9 +287,9 @@ if [[ $action = "c" ]]; then
 
   # prompt the results to user infinitely until they exit (escape)
   while true; do
-    choice=$(echo -e "$ids" | cut -d'	' -f2 | $promptcmd)       # dont show id
+    choice=$(echo -e "$ids" | cut -d$'\t' -f2 | $promptcmd)       # dont show id
     if [ -z "$choice" ]; then exit; fi                          # if esc-ed then exit
-    id=$(echo -e "$ids" | grep -Fwm1 "$choice" | cut -d'	' -f1) # get id of choice
+    id=$(echo -e "$ids" | grep -Fwm1 "$choice" | cut -d$'\t' -f1) # get id of choice
     echo -e "$choice\t($id)"
     case $id in
     ???????????) 
@@ -320,9 +328,9 @@ else
   playlink="https://youtube.com/playlist?list="
   # prompt the results to user infinitely until they exit (escape)
   while true; do
-    choice=$(echo -e "$ids" | cut -d'	' -f2 | $promptcmd)       # dont show id
+    choice=$(echo -e "$ids" | cut -d$'\t' -f2 | $promptcmd)       # dont show id
     if [ -z "$choice" ]; then exit; fi                          # if esc-ed then exit
-    id=$(echo -e "$ids" | grep -Fwm1 "$choice" | cut -d'	' -f1) # get id of choice
+    id=$(echo -e "$ids" | grep -Fwm1 "$choice" | cut -d$'\t' -f1) # get id of choice
     echo -e "$choice\t($id)"
     case $id in
     # 11 digit id = video


### PR DESCRIPTION
The YouTube script has been updated with watch history and playlist management features while preserving all existing functionality.

### New Features

####  Watch History (`-H`)
- Logs all played videos/playlists to `~/.config/yt/history`
- Format: `URL<TAB>Title<TAB>Timestamp`
- `-H` flag: Browse and replay from history  
- Supports GUI browsing with `-H -g`

####  Playlist Management (`-p`, `-P`)
- `-p`: View and play saved playlists from `~/.config/yt/playlists`
- `-P <url>`: Add a new playlist (with name prompt and URL validation)

### 🛠 Enhancements
- Automatically logs every played item (search, channel, playlist, history replay) to history

###  Files Created
- `~/.config/yt/history` — Watch history log  
- `~/.config/yt/playlists` — Saved playlists with custom names

###  Usage Examples
```bash
yt -H           # Browse watch history  
yt -H -g        # GUI mode for history  
yt -p           # List and play saved playlists  
yt -P <url>     # Add a new playlist
